### PR TITLE
Lean URL: fix for Nightly and website specific rules

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-var blockedParams = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+var globalBlockedParams = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
 
 function getParams(URL) {
     var splitURL = URL.split("?");
@@ -32,6 +32,16 @@ function buildURL(baseURL, params) {
     return newURL;
 }
 
+function getDomain(url) {
+	var arr = url.split("/")[2].split(".");
+	
+	if ( arr.length > 1 ) {
+		return arr[arr.length - 2] + "." + arr[arr.length - 1];
+	}
+	
+	return null;
+}
+
 function cleanURL(details) {
     var baseURL = details.url.split("?")[0];
 
@@ -40,13 +50,33 @@ function cleanURL(details) {
         return;
     }
 
-    var reducedParams = {};
-    for ( var key in params ) {
-        if ( !blockedParams.includes(key) ) {
-            reducedParams[key] = params[key];
-        }
-    }
-
+	var domain = getDomain(details.url);
+	if ( domain == null ) {
+		return;
+	}
+	
+	var blockedParams = [];
+	for (let gbp of globalBlockedParams) {
+		if (gbp.indexOf("@") == -1) {
+			blockedParams.push(gbp);
+			continue;
+		}
+		
+		var keyValue = gbp.split("@")[0];
+		var keyDomain = gbp.split("@")[1];
+			
+		if( domain == keyDomain ) {
+			blockedParams.push(keyValue);
+		}
+	}
+	
+	var reducedParams = {};
+	for ( var key in params ) {
+		if ( !blockedParams.includes(key) ) {
+			reducedParams[key] = params[key];
+		}
+	}
+	
     if ( Object.keys(reducedParams).length == Object.keys(params).length ) {
         return;
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   },
 
   "permissions": [
-    "webRequest", "webRequestBlocking"
+    "webRequest", "webRequestBlocking", "<all_urls>"
   ],
 
   "background": {


### PR DESCRIPTION
Hi,

I've implemented a fix and a feature in this pull request.

* Make Lean URL work for Nightly (fix)

It didn't work in Nightly. Adding <all_urls> to the manifest fixed this problem.

* Add support for @ sign for domain-specific garbage/tracking parameters (feature)

Global params like nb@tweakers.net now work if you include "nb@tweakers.net" in the globalBlockedParams array.

Example URL:
https://tweakers.net/nieuws/124721/lenovo-brengt-5-inch-moto-c-plus-met-4000mah-accu-begin-juni-uit-voor-119-euro.html?nb=2017-05-17&u=0900

I've implemented this feature so that Lean URL can be compatible with Pure URL rules.

I would be glad if you would accept this code. I've attempted to follow your code style.